### PR TITLE
Update Zed example

### DIFF
--- a/scripts/zed-settings.json
+++ b/scripts/zed-settings.json
@@ -1,24 +1,13 @@
 {
-  // Note: you'll need to install "Kotlin" extension via Zed extensions: https://github.com/zed-extensions/kotlin/blob/main/src/kotlin.rs
-  // This configuration basically overrides its executable
+  // Note: you'll need to install "Kotlin" extension via Zed extensions: https://github.com/zed-extensions/kotlin
+  // See the README.md file for more information on how to configure kotlin-lsp in Zed
   // Also note: diagnostics do not work because they are pull-based in our implementation, but the editor expects them to be push-based
   // Things like navigation, completion, find references and code actions like organize imports do.
   "languages": {
     "Kotlin": {
       "language_servers": [
-        "kotlin-language-server"
+        "kotlin-lsp"
       ]
-    }
-  },
-  "lsp": {
-    "kotlin-language-server": {
-      "binary": {
-        // NB!!: change this executable path to yours
-        "path": "/Users/qwwdfsad/Downloads/kotlin-lsp/kotlin-0.252.16764/kotlin-lsp.sh",
-        "arguments": [
-          "--stdio"
-        ]
-      }
     }
   }
 }


### PR DESCRIPTION
Hello! We (Zed) added opt-in support for `kotlin-lsp` in Zed through the existing Kotlin extension, making the Zed example configuration out-of-date. I've updated the configuration to reflect this, however, it may be better to simply point users at our extension (https://github.com/zed-extensions/kotlin) for the most up to date setup and configuration.

Thanks for making the effort to create an offical Kotlin LSP!
