### PR TITLE
Change `kotlin-lsp.sh` to use `/usr/bin/env` as its shebang

### DIFF
--- a/scripts/kotlin-lsp.sh
+++ b/scripts/kotlin-lsp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SOURCE=${BASH_SOURCE[0]}
 while [ -L "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink


### PR DESCRIPTION
This allows the script to be run in non-LFS compliant distros such as [NixOS](https://nixos.org)