### PR TITLE
Fix option name in Emacs lsp-mode config example

### DIFF
--- a/scripts/lsp-kotlin-emacs-lsp-mode.el
+++ b/scripts/lsp-kotlin-emacs-lsp-mode.el
@@ -1,5 +1,5 @@
 (defun kotlin-lsp-server-start-fun (port)
-     (list "kotlin-lsp.sh" "--port" (number-to-string port)))
+     (list "kotlin-lsp.sh" "--socket" (number-to-string port)))
 (with-eval-after-load 'lsp-mode
   (add-to-list 'lsp-language-id-configuration
 	       '(kotlin-mode . "kotlin"))


### PR DESCRIPTION
```
$ kotlin-lsp --help
Usage: kotlin-lsp [OPTIONS]

Options:
  --socket INT  A port which will be used for a Kotlin LSP connection. Default
                is 9999
  --stdio       Whether the Kotlin LSP server is used in stdio mode. If not
                set, server mode will be used with a port specified by
                `socket`
  --client      Whether the Kotlin LSP server is used in client mode. If not
                set, server mode will be used with a port specified by
                `socket`
  -h, --help    Show this message and exit
  ```