### PR TITLE
fix: vscode: Associate .kts file extension with Kotlin

### DIFF
--- a/kotlin-vscode/package.json
+++ b/kotlin-vscode/package.json
@@ -33,7 +33,8 @@
           "kotlin"
         ],
         "extensions": [
-          ".kt"
+          ".kt",
+          ".kts"
         ],
         "configuration": "./language-configuration.json"
       }


### PR DESCRIPTION
for things like scripts, gradle config, etc...