### PR TITLE
feat: intercept Kotlin go-to-definition for directories and open in E…

### DIFF
--- a/vscode-language-kotlin/src/kotlin/directoryNavigator.ts
+++ b/vscode-language-kotlin/src/kotlin/directoryNavigator.ts
@@ -1,0 +1,42 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+
+export function registerDirectoryNavigator(context: vscode.ExtensionContext) {
+    const disposable = vscode.commands.registerTextEditorCommand(
+        'editor.action.revealDefinition',
+        async (textEditor: vscode.TextEditor) => {
+            if (textEditor.document.languageId !== 'kotlin') {
+                return vscode.commands.executeCommand('vscode.executeDefinitionProvider',
+                    textEditor.document.uri, textEditor.selection.active);
+            }
+
+            const definitions = await vscode.commands.executeCommand<vscode.Location[]>(
+                'vscode.executeDefinitionProvider',
+                textEditor.document.uri,
+                textEditor.selection.active
+            );
+
+            if (!definitions?.length) return;
+
+            for (const def of definitions) {
+                try {
+                    const isDir = fs.statSync(def.uri.fsPath).isDirectory();
+                    if (isDir) {
+                        await vscode.commands.executeCommand('workbench.view.explorer');
+                        await vscode.commands.executeCommand('revealInExplorer', def.uri);
+                        return;
+                    }
+                } catch {}
+            }
+
+            for (const def of definitions) {
+                const document = await vscode.workspace.openTextDocument(def.uri);
+                await vscode.window.showTextDocument(document, {
+                    selection: def.range
+                });
+            }
+        }
+    );
+
+    context.subscriptions.push(disposable);
+}

--- a/vscode-language-kotlin/src/kotlin/module.ts
+++ b/vscode-language-kotlin/src/kotlin/module.ts
@@ -2,8 +2,10 @@ import { ExtensionContext } from 'vscode';
 import { DocumentParser } from '@jetbrains/vscode-extension-core/DocumentParser';
 import { registerHandleKeyType } from '@jetbrains/vscode-extension-core/handleKeyType';
 import keyHandler from './keyHandler';
+import { registerDirectoryNavigator } from './directoryNavigator';
 
 export default async (context: ExtensionContext) => {
     const parser = await DocumentParser.create(context, 'kotlin');
     registerHandleKeyType(context, parser, keyHandler);
+    registerDirectoryNavigator(context);
 };


### PR DESCRIPTION
…xplorer

Prevents VSCode from showing "file is not displayed because it is a directory"
errors when Kotlin LSP navigation points to package directories. Instead,
automatically opens the Explorer view and highlights the target directory.

- Override editor.action.revealDefinition for Kotlin files only
- Check if definition targets are directories vs files
- Open directories in Explorer, handle files normally
- Maintain existing behavior for non-Kotlin files